### PR TITLE
Updated GetCollectionNameFromType to use most derived type

### DIFF
--- a/lib/MongoRepository2/Util.cs
+++ b/lib/MongoRepository2/Util.cs
@@ -32,7 +32,7 @@
         private static IMongoDatabase GetDatabaseFromUrl(MongoUrl url)
         {
             var client = new MongoClient(url);
-            
+
             return client.GetDatabase(url.DatabaseName); // WriteConcern defaulted to Acknowledged
         }
 
@@ -157,12 +157,15 @@
             {
                 if (typeof(Entity).GetTypeInfo().IsAssignableFrom(entitytype))
                 {
-                    // No attribute found, get the basetype
-                    while (!typeInfo.BaseType.Equals(typeof(Entity)))
-                    {
-                        entitytype = typeInfo.BaseType;
-                    }
+                    // No attribute found, get the basetype. Recursively descend the type hierarchy 
+                    // until the last base type (deriving from Entity) is found.
+                    if (typeof(Entity).GetTypeInfo().IsAssignableFrom(entitytype))
+                        while (entitytype.GetTypeInfo().BaseType != typeof(Entity))
+                        {
+                            entitytype = typeInfo.BaseType;
+                        }
                 }
+
                 collectionname = entitytype.Name;
             }
 

--- a/lib/MongoRepository2/Util.cs
+++ b/lib/MongoRepository2/Util.cs
@@ -143,7 +143,7 @@
         /// <returns>Returns the collectionname from the specified type.</returns>
         private static string GetCollectionNameFromType(Type entitytype)
         {
-            string collectionname;
+            var collectionname = string.Empty;
 
             var typeInfo = entitytype.GetTypeInfo();
             // Check to see if the object (inherited from Entity) has a CollectionName attribute
@@ -151,22 +151,15 @@
             if (att != null)
             {
                 // It does! Return the value specified by the CollectionName attribute
-                collectionname = ((CollectionName)att).Name;
+                collectionname = att.Name;
             }
             else
             {
+                // Use the base type if it is assignable from type of Entity
                 if (typeof(Entity).GetTypeInfo().IsAssignableFrom(entitytype))
                 {
-                    // No attribute found, get the basetype. Recursively descend the type hierarchy 
-                    // until the last base type (deriving from Entity) is found.
-                    if (typeof(Entity).GetTypeInfo().IsAssignableFrom(entitytype))
-                        while (entitytype.GetTypeInfo().BaseType != typeof(Entity))
-                        {
-                            entitytype = typeInfo.BaseType;
-                        }
+                    collectionname = entitytype.Name;
                 }
-
-                collectionname = entitytype.Name;
             }
 
             return collectionname;


### PR DESCRIPTION
I made the following change in the `GetCollectionNameFromType` method in Util.cs to use the name of the most derived type rather the base type closest to Entity. 

For example, if someone has a base class of `Entity` from which they derive `Animal` from which they derive `Dog` from which they derive `GermanShepherd`, the collection would be named as `GermanShepherd`. 

If I am creating a collection of a given type, it should be assumed that I want the collection to have that name.

Basically, I just removed the while loop which recurred through the type hierarchy. 


                // Use the base type if it is assignable from type of Entity
                if (typeof(Entity).GetTypeInfo().IsAssignableFrom(entitytype))
                {
                    collectionname = entitytype.Name;
                }

